### PR TITLE
Remove try/catch around compile call

### DIFF
--- a/lib/i18n-lookup.js
+++ b/lib/i18n-lookup.js
@@ -23,9 +23,7 @@ module.exports = function (t, compiler) {
 
         return _.reduce(keys, function (message, token) {
             if (!message && t(token) !== token) {
-                try {
-                    message = compiler(t(token), context || {});
-                } catch (e) {}
+                message = compiler(t(token), context || {});
             }
             return message;
         }, null);


### PR DESCRIPTION
This prevents errors being thrown when someone breaks something in compiler.